### PR TITLE
Network 기본 설정 및 이슈 관련한 요청 객체 생성 

### DIFF
--- a/iOS/DoCollabo/DoCollabo.xcodeproj/project.pbxproj
+++ b/iOS/DoCollabo/DoCollabo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -17,11 +17,22 @@
 		30789C1F248E3FC1001D0415 /* UIView+Border.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30789C1E248E3FC1001D0415 /* UIView+Border.swift */; };
 		30AC784F248F94C4004BA3B6 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AC784E248F94C4004BA3B6 /* NetworkError.swift */; };
 		30AC7852248F95B9004BA3B6 /* ErrorAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AC7851248F95B9004BA3B6 /* ErrorAlertController.swift */; };
+		30E22EE52491064A00EC0FD8 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E22EE42491064A00EC0FD8 /* Request.swift */; };
+		30E22EE8249106A300EC0FD8 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 30E22EE7249106A300EC0FD8 /* Alamofire */; };
+		30E22EEA2491093100EC0FD8 /* NetworkDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E22EE92491093100EC0FD8 /* NetworkDispatcher.swift */; };
+		30E22EEC2491098200EC0FD8 /* Session+NetworkDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E22EEB2491098200EC0FD8 /* Session+NetworkDispatcher.swift */; };
+		30E22EEE249109EC00EC0FD8 /* FetchIssuesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E22EED249109EC00EC0FD8 /* FetchIssuesRequest.swift */; };
+		30E22EF024910BDA00EC0FD8 /* AddIssueRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E22EEF24910BDA00EC0FD8 /* AddIssueRequest.swift */; };
+		30E22EF324910D8700EC0FD8 /* FetchIssueRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E22EF224910D8700EC0FD8 /* FetchIssueRequest.swift */; };
+		30E22EF524910E3D00EC0FD8 /* DeleteIssueRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E22EF424910E3D00EC0FD8 /* DeleteIssueRequest.swift */; };
+		30E22EF824910EF800EC0FD8 /* IssueUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E22EF724910EF800EC0FD8 /* IssueUseCase.swift */; };
+		30E22EFB24910F9F00EC0FD8 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E22EFA24910F9F00EC0FD8 /* Issue.swift */; };
+		30E22EFD2491101A00EC0FD8 /* IssueLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E22EFC2491101A00EC0FD8 /* IssueLabel.swift */; };
 		386B8F99248E291100ED3A5A /* IssuesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386B8F98248E291100ED3A5A /* IssuesViewController.swift */; };
 		386B8F9D248E2B0200ED3A5A /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386B8F9C248E2B0200ED3A5A /* SignInViewController.swift */; };
 		38F0FB49248E2D870080FBBD /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0FB48248E2D870080FBBD /* Colors.swift */; };
 		38F0FB5C248E6E4C0080FBBD /* OAuthURLStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0FB5B248E6E4C0080FBBD /* OAuthURLStub.swift */; };
-		38F0FB5E248E73690080FBBD /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0FB5D248E73690080FBBD /* NetworkManager.swift */; };
+		38F0FB5E248E73690080FBBD /* OAuthNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0FB5D248E73690080FBBD /* OAuthNetworkManager.swift */; };
 		38F0FB62248FA23F0080FBBD /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0FB61248FA23F0080FBBD /* EndPoint.swift */; };
 /* End PBXBuildFile section */
 
@@ -38,11 +49,21 @@
 		30789C1E248E3FC1001D0415 /* UIView+Border.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Border.swift"; sourceTree = "<group>"; };
 		30AC784E248F94C4004BA3B6 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		30AC7851248F95B9004BA3B6 /* ErrorAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorAlertController.swift; sourceTree = "<group>"; };
+		30E22EE42491064A00EC0FD8 /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+		30E22EE92491093100EC0FD8 /* NetworkDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDispatcher.swift; sourceTree = "<group>"; };
+		30E22EEB2491098200EC0FD8 /* Session+NetworkDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Session+NetworkDispatcher.swift"; sourceTree = "<group>"; };
+		30E22EED249109EC00EC0FD8 /* FetchIssuesRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchIssuesRequest.swift; sourceTree = "<group>"; };
+		30E22EEF24910BDA00EC0FD8 /* AddIssueRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddIssueRequest.swift; sourceTree = "<group>"; };
+		30E22EF224910D8700EC0FD8 /* FetchIssueRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchIssueRequest.swift; sourceTree = "<group>"; };
+		30E22EF424910E3D00EC0FD8 /* DeleteIssueRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteIssueRequest.swift; sourceTree = "<group>"; };
+		30E22EF724910EF800EC0FD8 /* IssueUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueUseCase.swift; sourceTree = "<group>"; };
+		30E22EFA24910F9F00EC0FD8 /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
+		30E22EFC2491101A00EC0FD8 /* IssueLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueLabel.swift; sourceTree = "<group>"; };
 		386B8F98248E291100ED3A5A /* IssuesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuesViewController.swift; sourceTree = "<group>"; };
 		386B8F9C248E2B0200ED3A5A /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		38F0FB48248E2D870080FBBD /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		38F0FB5B248E6E4C0080FBBD /* OAuthURLStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthURLStub.swift; sourceTree = "<group>"; };
-		38F0FB5D248E73690080FBBD /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		38F0FB5D248E73690080FBBD /* OAuthNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthNetworkManager.swift; sourceTree = "<group>"; };
 		38F0FB61248FA23F0080FBBD /* EndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -51,6 +72,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				30E22EE8249106A300EC0FD8 /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,6 +98,7 @@
 		30789C06248E1E3F001D0415 /* DoCollabo */ = {
 			isa = PBXGroup;
 			children = (
+				30E22EF924910F8E00EC0FD8 /* Models */,
 				30789C20248E430F001D0415 /* Network */,
 				386B8F9A248E2AEE00ED3A5A /* SignIn */,
 				386B8F96248E28D800ED3A5A /* Issues */,
@@ -102,8 +125,12 @@
 		30789C20248E430F001D0415 /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				38F0FB5D248E73690080FBBD /* NetworkManager.swift */,
+				38F0FB5D248E73690080FBBD /* OAuthNetworkManager.swift */,
 				38F0FB61248FA23F0080FBBD /* EndPoint.swift */,
+				30E22EE92491093100EC0FD8 /* NetworkDispatcher.swift */,
+				30E22EEB2491098200EC0FD8 /* Session+NetworkDispatcher.swift */,
+				30E22EF624910EE600EC0FD8 /* UseCases */,
+				30E22EE32491063E00EC0FD8 /* Request */,
 				30AC7850248F9598004BA3B6 /* Views */,
 				30AC784D248F94B2004BA3B6 /* Errors */,
 				30789C23248E4332001D0415 /* Stubs */,
@@ -133,6 +160,43 @@
 				30AC7851248F95B9004BA3B6 /* ErrorAlertController.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		30E22EE32491063E00EC0FD8 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				30E22EE42491064A00EC0FD8 /* Request.swift */,
+				30E22EF124910C5200EC0FD8 /* Issue */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		30E22EF124910C5200EC0FD8 /* Issue */ = {
+			isa = PBXGroup;
+			children = (
+				30E22EED249109EC00EC0FD8 /* FetchIssuesRequest.swift */,
+				30E22EEF24910BDA00EC0FD8 /* AddIssueRequest.swift */,
+				30E22EF224910D8700EC0FD8 /* FetchIssueRequest.swift */,
+				30E22EF424910E3D00EC0FD8 /* DeleteIssueRequest.swift */,
+			);
+			path = Issue;
+			sourceTree = "<group>";
+		};
+		30E22EF624910EE600EC0FD8 /* UseCases */ = {
+			isa = PBXGroup;
+			children = (
+				30E22EF724910EF800EC0FD8 /* IssueUseCase.swift */,
+			);
+			path = UseCases;
+			sourceTree = "<group>";
+		};
+		30E22EF924910F8E00EC0FD8 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				30E22EFA24910F9F00EC0FD8 /* Issue.swift */,
+				30E22EFC2491101A00EC0FD8 /* IssueLabel.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		386B8F96248E28D800ED3A5A /* Issues */ = {
@@ -193,6 +257,9 @@
 			dependencies = (
 			);
 			name = DoCollabo;
+			packageProductDependencies = (
+				30E22EE7249106A300EC0FD8 /* Alamofire */,
+			);
 			productName = DoCollabo;
 			productReference = 30789C04248E1E3F001D0415 /* DoCollabo.app */;
 			productType = "com.apple.product-type.application";
@@ -221,6 +288,9 @@
 				Base,
 			);
 			mainGroup = 30789BFB248E1E3F001D0415;
+			packageReferences = (
+				30E22EE6249106A300EC0FD8 /* XCRemoteSwiftPackageReference "Alamofire" */,
+			);
 			productRefGroup = 30789C05248E1E3F001D0415 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -251,16 +321,26 @@
 				38F0FB5C248E6E4C0080FBBD /* OAuthURLStub.swift in Sources */,
 				30789C1F248E3FC1001D0415 /* UIView+Border.swift in Sources */,
 				386B8F99248E291100ED3A5A /* IssuesViewController.swift in Sources */,
-				38F0FB5E248E73690080FBBD /* NetworkManager.swift in Sources */,
+				30E22EEA2491093100EC0FD8 /* NetworkDispatcher.swift in Sources */,
+				30E22EEE249109EC00EC0FD8 /* FetchIssuesRequest.swift in Sources */,
+				38F0FB5E248E73690080FBBD /* OAuthNetworkManager.swift in Sources */,
+				30E22EF324910D8700EC0FD8 /* FetchIssueRequest.swift in Sources */,
 				30AC784F248F94C4004BA3B6 /* NetworkError.swift in Sources */,
 				38F0FB49248E2D870080FBBD /* Colors.swift in Sources */,
+				30E22EF824910EF800EC0FD8 /* IssueUseCase.swift in Sources */,
 				30789C0C248E1E3F001D0415 /* TabBarViewController.swift in Sources */,
 				30789C08248E1E3F001D0415 /* AppDelegate.swift in Sources */,
 				386B8F9D248E2B0200ED3A5A /* SignInViewController.swift in Sources */,
+				30E22EEC2491098200EC0FD8 /* Session+NetworkDispatcher.swift in Sources */,
+				30E22EFD2491101A00EC0FD8 /* IssueLabel.swift in Sources */,
 				30789C0A248E1E3F001D0415 /* SceneDelegate.swift in Sources */,
 				30AC7852248F95B9004BA3B6 /* ErrorAlertController.swift in Sources */,
+				30E22EE52491064A00EC0FD8 /* Request.swift in Sources */,
+				30E22EFB24910F9F00EC0FD8 /* Issue.swift in Sources */,
+				30E22EF524910E3D00EC0FD8 /* DeleteIssueRequest.swift in Sources */,
 				38F0FB62248FA23F0080FBBD /* EndPoint.swift in Sources */,
 				30789C1D248E3A37001D0415 /* LeadingImageButton.swift in Sources */,
+				30E22EF024910BDA00EC0FD8 /* AddIssueRequest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -458,6 +538,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		30E22EE6249106A300EC0FD8 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.2.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		30E22EE7249106A300EC0FD8 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 30E22EE6249106A300EC0FD8 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 30789BFC248E1E3F001D0415 /* Project object */;
 }

--- a/iOS/DoCollabo/DoCollabo/Models/Issue.swift
+++ b/iOS/DoCollabo/DoCollabo/Models/Issue.swift
@@ -1,0 +1,31 @@
+//
+//  Issues.swift
+//  DoCollabo
+//
+//  Created by delma on 2020/06/10.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import Foundation
+
+struct Issue: Codable {
+    var id: Int
+    var close: Bool
+    var title: String
+    var description: String
+    var createdAt: String
+    var updatedAt: String
+    var userId: String
+    var labels: [IssueLabel]
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case close
+        case title
+        case description = "content"
+        case createdAt
+        case updatedAt
+        case userId
+        case labels
+    }
+}

--- a/iOS/DoCollabo/DoCollabo/Models/IssueLabel.swift
+++ b/iOS/DoCollabo/DoCollabo/Models/IssueLabel.swift
@@ -1,0 +1,23 @@
+//
+//  IssueLabel.swift
+//  DoCollabo
+//
+//  Created by delma on 2020/06/10.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import Foundation
+
+struct IssueLabel: Codable {
+    var id: Int
+    var title: String
+    var color: String
+    var description: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case color
+        case description = "content"
+    }
+}

--- a/iOS/DoCollabo/DoCollabo/Network/EndPoint.swift
+++ b/iOS/DoCollabo/DoCollabo/Network/EndPoint.swift
@@ -9,7 +9,9 @@
 import Foundation
 
 enum EndPoint {
-    static let baseURL: String = "http://52.79.81.75:8080"
+    static let baseURL: String = "http://52.79.81.75:8080/api"
     static let githubOAuth: String = "\(Self.baseURL)/oauth2/authorization/github"
     static let githubURLScheme: String = "github.docollabo.app"
+    static let issues: String = "\(Self.baseURL)/issues"
+    static let labels: String = "\(Self.baseURL)/labels"
 }

--- a/iOS/DoCollabo/DoCollabo/Network/NetworkDispatcher.swift
+++ b/iOS/DoCollabo/DoCollabo/Network/NetworkDispatcher.swift
@@ -1,0 +1,13 @@
+//
+//  NetworkDispatcher.swift
+//  DoCollabo
+//
+//  Created by delma on 2020/06/10.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import Foundation
+
+protocol NetworkDispatcher {
+    func execute(request: URLRequest, handler: @escaping (Data?) -> Void)
+}

--- a/iOS/DoCollabo/DoCollabo/Network/OAuthNetworkManager.swift
+++ b/iOS/DoCollabo/DoCollabo/Network/OAuthNetworkManager.swift
@@ -9,7 +9,7 @@
 import Foundation
 import AuthenticationServices
 
-final class NetworkManager {
+final class OAuthNetworkManager {
     private var session: ASWebAuthenticationSession?
     
     func authenticateWithGithub(

--- a/iOS/DoCollabo/DoCollabo/Network/Request/Issue/AddIssueRequest.swift
+++ b/iOS/DoCollabo/DoCollabo/Network/Request/Issue/AddIssueRequest.swift
@@ -1,0 +1,14 @@
+//
+//  AddIssueRequest.swift
+//  DoCollabo
+//
+//  Created by delma on 2020/06/10.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import Foundation
+
+struct AddIssueRequest: Request {
+    var path: String = EndPoint.issues
+    var method: HTTPMethod = .POST
+}

--- a/iOS/DoCollabo/DoCollabo/Network/Request/Issue/DeleteIssueRequest.swift
+++ b/iOS/DoCollabo/DoCollabo/Network/Request/Issue/DeleteIssueRequest.swift
@@ -1,0 +1,20 @@
+//
+//  DeleteIssueRequest.swift
+//  DoCollabo
+//
+//  Created by delma on 2020/06/10.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import Foundation
+
+struct DeleteIssueRequest: Request {
+    var id: String
+    var path: String = EndPoint.issues
+    var method: HTTPMethod = .DELETE
+    
+    init(id: String) {
+        self.id = id
+        path += "/" + id
+    }
+}

--- a/iOS/DoCollabo/DoCollabo/Network/Request/Issue/FetchIssueRequest.swift
+++ b/iOS/DoCollabo/DoCollabo/Network/Request/Issue/FetchIssueRequest.swift
@@ -1,0 +1,19 @@
+//
+//  FetchIssueRequest.swift
+//  DoCollabo
+//
+//  Created by delma on 2020/06/10.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import Foundation
+
+struct FetchIssueRequest: Request {
+    var id: String
+    var path: String = EndPoint.issues
+    
+    init(id: String) {
+        self.id = id
+        path += "/" + id
+    }
+}

--- a/iOS/DoCollabo/DoCollabo/Network/Request/Issue/FetchIssuesRequest.swift
+++ b/iOS/DoCollabo/DoCollabo/Network/Request/Issue/FetchIssuesRequest.swift
@@ -1,0 +1,13 @@
+//
+//  FetchIssuesRequest.swift
+//  DoCollabo
+//
+//  Created by delma on 2020/06/10.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import Foundation
+
+struct FetchIssuesRequest: Request {
+    var path: String = EndPoint.issues
+}

--- a/iOS/DoCollabo/DoCollabo/Network/Request/Request.swift
+++ b/iOS/DoCollabo/DoCollabo/Network/Request/Request.swift
@@ -1,0 +1,42 @@
+//
+//  Request.swift
+//  DoCollabo
+//
+//  Created by delma on 2020/06/10.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+enum HTTPMethod: String {
+    case GET, POST, PUT, PATCH, DELETE
+}
+
+protocol Request {
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var headers: HTTPHeaders? { get }
+    var bodyParams: [String : Any]? { get }
+    func setToken() -> HTTPHeaders?
+    func asURLRequest() -> URLRequest
+}
+
+extension Request {
+    var method: HTTPMethod { return .GET }
+    var headers: HTTPHeaders? { return nil }
+    var bodyParams: [String : Any]? { return nil }
+    func setToken() -> HTTPHeaders? {
+        guard let token = UserDefaults.standard.object(forKey: .jwtToken) as? String else { return nil }
+        let headers: HTTPHeaders = ["Authorization": token]
+        return headers
+    }
+    
+    func asURLRequest() -> URLRequest {
+        var request = URLRequest(url: URL(string: path)!)
+        request.httpMethod = self.method.rawValue
+        guard let headersWithToken = setToken() else { return request }
+        request.headers = headersWithToken
+        return request
+    }
+}

--- a/iOS/DoCollabo/DoCollabo/Network/Session+NetworkDispatcher.swift
+++ b/iOS/DoCollabo/DoCollabo/Network/Session+NetworkDispatcher.swift
@@ -1,0 +1,18 @@
+//
+//  Session+NetworkDispatcher.swift
+//  DoCollabo
+//
+//  Created by delma on 2020/06/10.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+extension Session: NetworkDispatcher {
+    func execute(request: URLRequest, handler: @escaping (Data?) -> Void) {
+        self.request(request).validate().response { response in
+            handler(response.data)
+        }
+    }
+}

--- a/iOS/DoCollabo/DoCollabo/Network/UseCases/IssueUseCase.swift
+++ b/iOS/DoCollabo/DoCollabo/Network/UseCases/IssueUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  IssueUseCase.swift
+//  DoCollabo
+//
+//  Created by delma on 2020/06/10.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import Foundation
+
+struct IssueUseCase {
+    var request: URLRequest
+    var networkDispatcher: NetworkDispatcher
+    
+    init(request: URLRequest, networkDispatcher: NetworkDispatcher) {
+        self.request = request
+        self.networkDispatcher = networkDispatcher
+    }
+    
+    func perform<T: Codable>(dataType: T.Type, handler: @escaping (T) -> ()) {
+      networkDispatcher.execute(request: request) { (data) in
+        guard let data = data else { return }
+        guard let decodedData = try? JSONDecoder().decode(dataType, from: data) else { return }
+        handler(decodedData)
+      }
+    }
+}

--- a/iOS/DoCollabo/DoCollabo/SignIn/Controllers/SignInViewController.swift
+++ b/iOS/DoCollabo/DoCollabo/SignIn/Controllers/SignInViewController.swift
@@ -11,12 +11,12 @@ import AuthenticationServices
 
 final class SignInViewController: UIViewController {
 
-    private var networkManager: NetworkManager!
+    private var networkManager: OAuthNetworkManager!
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        networkManager = NetworkManager()
+        networkManager = OAuthNetworkManager()
     }
 }
 


### PR DESCRIPTION
### 구현 사항
- 이슈 모델 생성
- 이슈 레이블 모델 생성 
- Request 프로토콜 생성 및 익스텐션으로 기본 기능 구현 
- 이슈 관련한 요청 보낼 객체들 생성 (`FetchIssuesRequest`, `AddIssueRequest`,`FetchIssueRequest`, `DeleteIssueRequest`)
- NetworkDispatcher 생성
- Alamofire Session이 NetworkDispatcher 채택 
- NetworkManager의 이름을 OAuthNetworkManager로 변경 