### PR TITLE
IssueHorizontalCell dynamic height 구현

### DIFF
--- a/iOS/DoCollabo/DoCollabo/Base.lproj/Main.storyboard
+++ b/iOS/DoCollabo/DoCollabo/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oYW-wY-9vJ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oYW-wY-9vJ">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -31,20 +31,20 @@
                                     <constraint firstAttribute="height" constant="144" id="mMr-bD-8v0"/>
                                 </constraints>
                             </view>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="A8O-zc-ada" customClass="IssuesCollectionView" customModule="DoCollabo" customModuleProvider="target">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ei8-PE-PvC" customClass="IssuesCollectionView" customModule="DoCollabo" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="188" width="414" height="625"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="tTw-9I-mle">
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="bWw-TV-tTY">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="bas-cC-bVq">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="Bse-mC-Eka">
                                         <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="yDQ-dD-eD4">
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="4v6-BK-Yjl">
                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </collectionViewCellContentView>
@@ -58,17 +58,17 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="A8O-zc-ada" secondAttribute="trailing" id="EBb-41-hjF"/>
+                            <constraint firstItem="ei8-PE-PvC" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="Ah1-p0-KGe"/>
                             <constraint firstItem="4S6-US-nCZ" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="HmP-HD-RqN"/>
                             <constraint firstItem="7rp-jf-7jW" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="QiE-ON-sSo"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="A8O-zc-ada" secondAttribute="bottom" id="WUv-XL-hAO"/>
                             <constraint firstItem="QHS-ei-5er" firstAttribute="trailing" secondItem="4S6-US-nCZ" secondAttribute="trailing" id="X4Y-ev-Rf3"/>
                             <constraint firstItem="QHS-ei-5er" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="YUD-6r-XHH"/>
                             <constraint firstItem="7rp-jf-7jW" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Yda-xW-ryu"/>
-                            <constraint firstItem="A8O-zc-ada" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="cny-F8-Ga8"/>
+                            <constraint firstItem="ei8-PE-PvC" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="ejY-Tc-fjq"/>
                             <constraint firstItem="4S6-US-nCZ" firstAttribute="leading" secondItem="QHS-ei-5er" secondAttribute="leading" id="j2E-Le-0nE"/>
+                            <constraint firstItem="ei8-PE-PvC" firstAttribute="top" secondItem="4S6-US-nCZ" secondAttribute="bottom" id="oGl-0l-Usz"/>
                             <constraint firstItem="QHS-ei-5er" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="qkB-RQ-QBI"/>
-                            <constraint firstItem="A8O-zc-ada" firstAttribute="top" secondItem="4S6-US-nCZ" secondAttribute="bottom" id="tlx-HZ-Zq1"/>
+                            <constraint firstItem="ei8-PE-PvC" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="sHT-WJ-twY"/>
                             <constraint firstItem="QHS-ei-5er" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.95" id="w28-wm-nCg"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -76,7 +76,7 @@
                     <tabBarItem key="tabBarItem" title="Issues" id="zRf-ee-Xos"/>
                     <connections>
                         <outlet property="activityIndicator" destination="7rp-jf-7jW" id="BiU-W8-l4z"/>
-                        <outlet property="issuesCollectionView" destination="A8O-zc-ada" id="ea6-Mf-Xkh"/>
+                        <outlet property="issuesCollectionView" destination="ei8-PE-PvC" id="0KY-LB-fAa"/>
                         <outlet property="titleHeaderBackgroundView" destination="QHS-ei-5er" id="Had-li-EhF"/>
                         <outlet property="titleHeaderBackgroundViewHeightAnchor" destination="dqc-th-NxY" id="wPg-iI-Rbc"/>
                         <outlet property="titleHeaderBackgroundViewTopAnchor" destination="YUD-6r-XHH" id="tOs-BV-H0p"/>

--- a/iOS/DoCollabo/DoCollabo/Base.lproj/Main.storyboard
+++ b/iOS/DoCollabo/DoCollabo/Base.lproj/Main.storyboard
@@ -34,7 +34,7 @@
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ei8-PE-PvC" customClass="IssuesCollectionView" customModule="DoCollabo" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="188" width="414" height="625"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="bWw-TV-tTY">
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="bWw-TV-tTY">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>

--- a/iOS/DoCollabo/DoCollabo/Issues/Controllers/IssuesViewController.swift
+++ b/iOS/DoCollabo/DoCollabo/Issues/Controllers/IssuesViewController.swift
@@ -171,7 +171,7 @@ extension IssuesViewController: UICollectionViewDelegateFlowLayout {
         let estimatedHeight: CGFloat = 300.0
         let estimatedSizeCell = IssueHorizontalCell(
             frame: CGRect(x: 0, y: 0, width: width, height: estimatedHeight))
-        dataSource.issueForIndexPath(at: indexPath) { (issue) in
+        dataSource.referIssue(at: indexPath) { (issue) in
             estimatedSizeCell.configureCell(with: issue)
         }
         estimatedSizeCell.layoutIfNeeded()

--- a/iOS/DoCollabo/DoCollabo/Issues/Controllers/IssuesViewController.swift
+++ b/iOS/DoCollabo/DoCollabo/Issues/Controllers/IssuesViewController.swift
@@ -162,4 +162,21 @@ extension IssuesViewController: UICollectionViewDelegateFlowLayout {
         minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
         return 12.0
     }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let width = view.frame.width * 0.85
+        let estimatedHeight: CGFloat = 300.0
+        let estimatedSizeCell = IssueHorizontalCell(
+            frame: CGRect(x: 0, y: 0, width: width, height: estimatedHeight))
+        dataSource.issueForIndexPath(at: indexPath) { (issue) in
+            estimatedSizeCell.configureCell(with: issue)
+        }
+        estimatedSizeCell.layoutIfNeeded()
+        let estimatedSize = estimatedSizeCell.systemLayoutSizeFitting(
+            CGSize(width: width, height: estimatedHeight))
+        return CGSize(width: width, height: estimatedSize.height)
+    }
 }

--- a/iOS/DoCollabo/DoCollabo/Issues/DataSource/IssuesCollectionViewDataSource.swift
+++ b/iOS/DoCollabo/DoCollabo/Issues/DataSource/IssuesCollectionViewDataSource.swift
@@ -23,7 +23,7 @@ final class IssuesCollectionViewDataSource: NSObject, UICollectionViewDataSource
         self.changedHandler = changedHandler
     }
     
-    func issueForIndexPath(at indexPath: IndexPath, handler: (Issue) -> Void) {
+    func referIssue(at indexPath: IndexPath, handler: (Issue) -> Void) {
         let issue = issues[indexPath.item]
         handler(issue)
     }

--- a/iOS/DoCollabo/DoCollabo/Issues/DataSource/IssuesCollectionViewDataSource.swift
+++ b/iOS/DoCollabo/DoCollabo/Issues/DataSource/IssuesCollectionViewDataSource.swift
@@ -23,6 +23,11 @@ final class IssuesCollectionViewDataSource: NSObject, UICollectionViewDataSource
         self.changedHandler = changedHandler
     }
     
+    func issueForIndexPath(at indexPath: IndexPath, handler: (Issue) -> Void) {
+        let issue = issues[indexPath.item]
+        handler(issue)
+    }
+    
     func updateNotify(handler: @escaping ([Issue]) -> Void) {
         self.changedHandler = handler
     }

--- a/iOS/DoCollabo/DoCollabo/Issues/Views/IssueLabels/IssueLabelsCollectionView.swift
+++ b/iOS/DoCollabo/DoCollabo/Issues/Views/IssueLabels/IssueLabelsCollectionView.swift
@@ -29,10 +29,8 @@ final class IssueLabelsCollectionView: UICollectionView {
     private func configure() {
         backgroundColor = .white
         registerCollectionViewCell()
-        isScrollEnabled = true
+        isScrollEnabled = false
         showsHorizontalScrollIndicator = false
-        let layout = collectionViewLayout as! UICollectionViewFlowLayout
-        layout.scrollDirection = .horizontal
         dataSource = self
         delegate = self
     }

--- a/iOS/DoCollabo/DoCollabo/Issues/Views/Issues/IssueHorizontalCell.swift
+++ b/iOS/DoCollabo/DoCollabo/Issues/Views/Issues/IssueHorizontalCell.swift
@@ -40,7 +40,9 @@ final class IssueHorizontalCell: UICollectionViewCell {
             let collectionView = IssueLabelsCollectionView()
             collectionView.updateLabels(issue.labels)
             contentsStackView.addArrangedSubview(collectionView)
-            collectionView.heightAnchor.constraint(equalToConstant: 36).isActive = true
+            layoutIfNeeded()
+            let contentHeight = collectionView.contentSize.height
+            collectionView.heightAnchor.constraint(equalToConstant: contentHeight).isActive = true
         }
     }
     
@@ -67,8 +69,7 @@ final class IssueHorizontalCell: UICollectionViewCell {
             leadingAnchor: leadingAnchor,
             bottomAnchor: bottomAnchor,
             trailingAnchor: trailingAnchor,
-            padding: .init(top: 12, left: 16, bottom: 12, right: 16),
-            size: .init(width: UIScreen.main.bounds.width * 0.8, height: 0))
+            padding: .init(top: 12, left: 16, bottom: 12, right: 16))
     }
     
     override func prepareForReuse() {


### PR DESCRIPTION
`IssueHorizontalCell` 내부에 subview로 추가될 `IssueLabelsCollectionVIew`의 높이가 동적으로 결정되기 때문에 
`layoutIfNeeded()`를 사용해서 `IssueLabelsCollectionVIew`의 layout을 잡아 준 후에 기본적으로 collectionViewLayout이 잡아주는 contentHeight로 높이를 설정해주었습니다.

그 후에는 내부 아이템들의 높이가 모두 설정 되었고, autoLayout도 잘 잡혀져 있기 때문에 `IssueHorizontalCell`의 높이를 `systemLayoutSizeFitting(:)` 메소드를 사용하여 사이즈를 설정해주었습니다.

처음에 레이아웃이 깨지는 현상은 `issuesCollectionView`의 `UICollectionViewFlowLayout`의 `estimatedItemSize`를 `automatic`으로 설정해서 깨졌습니다. 이를 `none`으로 변경하니 해결되었습니다.

하지만 왜 다른탭으로 전환 후 다시 돌아오면 정상적으로 적용되는지는 의문입니다.