### PR TITLE
다크모드 대응

### DIFF
--- a/iOS/DoCollabo/DoCollabo/Base.lproj/Main.storyboard
+++ b/iOS/DoCollabo/DoCollabo/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oYW-wY-9vJ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oYW-wY-9vJ">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>

--- a/iOS/DoCollabo/DoCollabo/Issues/Views/IssueLabels/IssueLabelsCollectionView.swift
+++ b/iOS/DoCollabo/DoCollabo/Issues/Views/IssueLabels/IssueLabelsCollectionView.swift
@@ -27,7 +27,7 @@ final class IssueLabelsCollectionView: UICollectionView {
     }
     
     private func configure() {
-        backgroundColor = .white
+        backgroundColor = .tertiarySystemBackground
         registerCollectionViewCell()
         isScrollEnabled = false
         showsHorizontalScrollIndicator = false

--- a/iOS/DoCollabo/DoCollabo/Issues/Views/Issues/IssueHorizontalCell.swift
+++ b/iOS/DoCollabo/DoCollabo/Issues/Views/Issues/IssueHorizontalCell.swift
@@ -52,7 +52,7 @@ final class IssueHorizontalCell: UICollectionViewCell {
     }
     
     private func configureUI() {
-        backgroundColor = .white
+        backgroundColor = .tertiarySystemBackground
         
         titleLabel = IssueHorizontalTitleLabel()
         contentsStackView = IssueHorizontalContentsStackView(arrangedSubviews: [titleLabel])

--- a/iOS/DoCollabo/DoCollabo/Issues/Views/TitleHeaderView.xib
+++ b/iOS/DoCollabo/DoCollabo/Issues/Views/TitleHeaderView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -26,13 +26,13 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7CZ-o7-xGD">
                             <rect key="frame" x="20" y="44" width="105.5" height="48"/>
                             <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="40"/>
-                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <color key="textColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TAe-45-RYa">
                             <rect key="frame" x="181.5" y="12" width="51" height="24"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
-                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <color key="textColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                     </subviews>

--- a/iOS/DoCollabo/DoCollabo/Labels/Views/LabelCell.swift
+++ b/iOS/DoCollabo/DoCollabo/Labels/Views/LabelCell.swift
@@ -28,6 +28,8 @@ class LabelCell: UICollectionViewCell {
         drawShadow(color: .darkGray, offset: CGSize(width: 1, height: 1), radius: 4, opacity: 0.3)
         background.roundCorner(cornerRadius: 8.0)
         titleBackground.roundCorner(cornerRadius: IssueLabelCell.cornerRadius)
+        descriptionLabel.textColor = .label
+        background.backgroundColor = .tertiarySystemBackground
     }
     
     func configureCell(with label: IssueLabel) {


### PR DESCRIPTION
### 구현 내용
WWDC 영상 참고하여 다크모드 설정 추가했습니다
- 다크모드시 셀의 배경색도 라이트모드처럼 뒷 배경과 동일하게 하고, 섀도우 컬러를 흰색으로 주고자 하였으나 
구현 결과 가시성이 떨어져 완전한 검정색이 아닌 어두운 회색이 되도록 설정했습니다.
- 라이트모드에서 `TitleHeaderView`의 타이틀 컬러가 흰색이어서 레이블의 컬러를 `LabelColor`가 아닌 `SystemBackground`로 설정했습니다(`LabelColor`로 설정시 라이트모드에선 검정색/다크모드에선 흰색이므로)

### 구현 화면 
<img src = "https://user-images.githubusercontent.com/40784518/84630660-3bcb8380-af27-11ea-9012-731ce5e4c2c1.png" width = 50%/>